### PR TITLE
Fix lint issues in i18n modules and extension

### DIFF
--- a/src/exports/thea-code.d.ts
+++ b/src/exports/thea-code.d.ts
@@ -162,7 +162,7 @@ type ProviderSettings = {
 	modelMaxTokens?: number | undefined
 	modelMaxThinkingTokens?: number | undefined
 	includeMaxTokens?: boolean | undefined
-	fakeAi?: unknown | undefined
+        fakeAi?: unknown
 }
 
 type GlobalSettings = {

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -163,7 +163,7 @@ type ProviderSettings = {
 	modelMaxTokens?: number | undefined
 	modelMaxThinkingTokens?: number | undefined
 	includeMaxTokens?: boolean | undefined
-	fakeAi?: unknown | undefined
+        fakeAi?: unknown
 }
 
 export type { ProviderSettings }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ let extensionContext: vscode.ExtensionContext
 // Your extension is activated the very first time the command is executed.
 export async function activate(context: vscode.ExtensionContext) {
 	extensionContext = context
-	outputChannel = vscode.window.createOutputChannel(EXTENSION_DISPLAY_NAME)
+        outputChannel = vscode.window.createOutputChannel(String(EXTENSION_DISPLAY_NAME))
 	context.subscriptions.push(outputChannel)
 	outputChannel.appendLine(`${EXTENSION_DISPLAY_NAME} extension activated`)
 
@@ -54,13 +54,16 @@ export async function activate(context: vscode.ExtensionContext) {
 	telemetryService.initialize()
 
 	// Initialize i18n for internationalization support
-	initializeI18n(context.globalState.get("language") ?? formatLanguage(vscode.env.language))
+        await initializeI18n(
+                context.globalState.get("language") ?? formatLanguage(vscode.env.language),
+        )
 
 	// Initialize terminal shell execution handlers.
 	TerminalRegistry.initialize()
 
 	// Get default commands from configuration.
-	const defaultCommands = vscode.workspace.getConfiguration(configSection()).get<string[]>("allowedCommands") || []
+        const defaultCommands =
+                vscode.workspace.getConfiguration((configSection as () => string)()).get<string[]>("allowedCommands") || []
 
 	// Initialize global state if not already set.
 	if (!context.globalState.get("allowedCommands")) {
@@ -70,12 +73,12 @@ export async function activate(context: vscode.ExtensionContext) {
 	const provider = new TheaProvider(context, outputChannel, "sidebar") // Renamed constructor
 	telemetryService.setProvider(provider)
 
-	context.subscriptions.push(
-		vscode.window.registerWebviewViewProvider(TheaProvider.sideBarId, provider, {
-			// Renamed static property access
-			webviewOptions: { retainContextWhenHidden: true },
-		}),
-	)
+        context.subscriptions.push(
+                vscode.window.registerWebviewViewProvider(String(TheaProvider.sideBarId), provider, {
+                        // Renamed static property access
+                        webviewOptions: { retainContextWhenHidden: true },
+                }),
+        )
 
 	registerCommands({ context, outputChannel, provider })
 

--- a/src/i18n/__mocks__/index.ts
+++ b/src/i18n/__mocks__/index.ts
@@ -1,6 +1,7 @@
 // Mock implementation for i18n
 const i18nMock = {
-	t: jest.fn().mockImplementation((key: string, options?: Record<string, any>): string => {
+        t: jest.fn().mockImplementation((key: string, _options?: Record<string, unknown>): string => {
+                void _options
 		// Map specific keys to the exact strings expected in tests
 		const translationMap: Record<string, string> = {
 			"common:confirmation.reset_state": "Are you sure you want to reset all state?",
@@ -10,7 +11,7 @@ const i18nMock = {
 		// Return the mapped translation or the original key
 		return translationMap[key] || key
 	}),
-	changeLanguage: jest.fn(),
+        changeLanguage: jest.fn(),
 	getCurrentLanguage: jest.fn().mockReturnValue("en"),
 	initializeI18n: jest.fn(),
 }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -5,8 +5,8 @@ import i18next from "./setup"
  *
  * @param language The language code to use
  */
-export function initializeI18n(language: string): void {
-	i18next.changeLanguage(language)
+export async function initializeI18n(language: string): Promise<void> {
+        await i18next.changeLanguage(language)
 }
 
 /**
@@ -23,8 +23,8 @@ export function getCurrentLanguage(): string {
  *
  * @param language The language code to change to
  */
-export function changeLanguage(language: string): void {
-	i18next.changeLanguage(language)
+export async function changeLanguage(language: string): Promise<void> {
+        await i18next.changeLanguage(language)
 }
 
 /**
@@ -34,8 +34,8 @@ export function changeLanguage(language: string): void {
  * @param options Options for interpolation or pluralization
  * @returns The translated string
  */
-export function t(key: string, options?: Record<string, any>): string {
-	return i18next.t(key, options)
+export function t(key: string, options?: Record<string, unknown>): string {
+        return i18next.t(key, options)
 }
 
 export default i18next


### PR DESCRIPTION
## Summary
- follow documentation from `cline_docs` around architectural planning
- lint the project and fix the bottom three files with errors
- update i18n utilities to return promises
- fix unused variables in i18n mock
- cast constants in extension code to satisfy ESLint
- clean up generated types

## Testing
- `nvm exec npm run lint` *(fails: 1074 problems)*