### PR TITLE
Fix lint errors in webview tests

### DIFF
--- a/src/core/webview/__tests__/TheaStateManager.test.ts
+++ b/src/core/webview/__tests__/TheaStateManager.test.ts
@@ -1,4 +1,5 @@
 // filepath: /Volumes/stuff/Projects/Thea-Code/src/core/webview/__tests__/ClineStateManager.test.ts
+/* eslint-disable @typescript-eslint/unbound-method */
 import * as vscode from "vscode"
 import * as os from "os"
 import { TheaStateManager } from "../thea/TheaStateManager" // Renamed import and path
@@ -235,12 +236,12 @@ describe("TheaStateManager", () => {
 		expect(mockContextProxy.setValue).toHaveBeenCalledWith("diffEnabled", false)
 	})
 
-	test("getGlobalState delegates to contextProxy.getValue", async () => {
-		// Setup
-		mockContextProxy.getValue.mockImplementation(() => Promise.resolve(true))
+        test("getGlobalState delegates to contextProxy.getValue", () => {
+                // Setup
+                mockContextProxy.getValue.mockImplementation(() => Promise.resolve(true))
 
-		// Execute
-		const result = await stateManager.getGlobalState("diffEnabled")
+                // Execute
+                const result = stateManager.getGlobalState("diffEnabled")
 
 		// Verify
 		expect(mockContextProxy.getValue).toHaveBeenCalledWith("diffEnabled")
@@ -255,12 +256,12 @@ describe("TheaStateManager", () => {
 		expect(mockContextProxy.setValue).toHaveBeenCalledWith("diffEnabled", false)
 	})
 
-	test("getValue delegates to contextProxy.getValue", async () => {
-		// Setup
-		mockContextProxy.getValue.mockImplementation(() => Promise.resolve(true))
+        test("getValue delegates to contextProxy.getValue", () => {
+                // Setup
+                mockContextProxy.getValue.mockImplementation(() => Promise.resolve(true))
 
-		// Execute
-		const result = await stateManager.getValue("diffEnabled")
+                // Execute
+                const result = stateManager.getValue("diffEnabled")
 
 		// Verify
 		expect(mockContextProxy.getValue).toHaveBeenCalledWith("diffEnabled")

--- a/src/core/webview/__tests__/TheaTaskHistory.test.ts
+++ b/src/core/webview/__tests__/TheaTaskHistory.test.ts
@@ -1,11 +1,11 @@
 // filepath: /Volumes/stuff/Projects/Thea-Code/src/core/webview/__tests__/ClineTaskHistory.test.ts
+/* eslint-disable @typescript-eslint/unbound-method */
 import * as vscode from "vscode"
 import * as path from "path"
 import fs from "fs/promises"
 import { TheaTaskHistory } from "../history/TheaTaskHistory" // Updated import
 import { ContextProxy } from "../../config/ContextProxy"
 import { fileExistsAtPath } from "../../../utils/fs"
-import { TheaTask } from "../../TheaTask" // Renamed import
 import { ShadowCheckpointService } from "../../../services/checkpoints/ShadowCheckpointService"
 import { downloadTask } from "../../../integrations/misc/export-markdown"
 import { getWorkspacePath } from "../../../utils/path"
@@ -22,9 +22,9 @@ jest.mock("../../../services/checkpoints/ShadowCheckpointService")
 jest.mock("../../../integrations/misc/export-markdown")
 jest.mock("../../../utils/path")
 jest.mock("../../../shared/storagePathManager", () => ({
-	getTaskDirectoryPath: jest.fn().mockImplementation(async (storagePath, id) => {
-		return path.join(storagePath, "tasks", id)
-	}),
+        getTaskDirectoryPath: jest.fn().mockImplementation(
+                (storagePath: string, id: string) => path.join(storagePath, "tasks", id),
+        ),
 }))
 
 describe("TheaTaskHistory", () => {
@@ -212,9 +212,9 @@ describe("TheaTaskHistory", () => {
 			mockContextProxy.getValue.mockImplementation(() => Promise.resolve([]))
 
 			// Mock the deleteTaskFromState method
-			const deleteTaskFromStateSpy = jest
-				.spyOn(taskHistory as any, "deleteTaskFromState")
-				.mockResolvedValue(undefined)
+                        const deleteTaskFromStateSpy = jest
+                                .spyOn(taskHistory, "deleteTaskFromState")
+                                .mockResolvedValue(undefined)
 
 			// Execute & Verify
 			await expect(taskHistory.getTaskWithId("non-existent-id")).rejects.toThrow("Task non-existent-id not found")
@@ -257,9 +257,9 @@ describe("TheaTaskHistory", () => {
 				tokensOut: 200,
 				totalCost: 0.01,
 			}
-			const mockGetTaskWithId = jest
-				.spyOn(taskHistory as any, "getTaskWithId")
-				.mockResolvedValue({ historyItem: mockHistoryItem })
+                        const mockGetTaskWithId = jest
+                                .spyOn(taskHistory, "getTaskWithId")
+                                .mockResolvedValue({ historyItem: mockHistoryItem })
 
 			const mockGetCurrentCline = jest.fn().mockReturnValue({ taskId: "current-task-id" }) // Keep as is, represents return value
 			const mockInitClineWithHistoryItem = jest.fn().mockResolvedValue({ taskId: mockHistoryItem.id }) // Keep as is, represents return value
@@ -285,7 +285,7 @@ describe("TheaTaskHistory", () => {
 			const mockGetCurrentCline = jest.fn().mockReturnValue({ taskId: "current-task-id" })
 			const mockInitClineWithHistoryItem = jest.fn()
 			const mockPostWebviewAction = jest.fn().mockResolvedValue(undefined)
-			const mockGetTaskWithId = jest.spyOn(taskHistory as any, "getTaskWithId")
+                        const mockGetTaskWithId = jest.spyOn(taskHistory, "getTaskWithId")
 
 			// Execute
 			await taskHistory.showTaskWithId(
@@ -315,8 +315,8 @@ describe("TheaTaskHistory", () => {
 				totalCost: 0.01,
 			}
 			const mockApiHistory = [{ role: "user", content: "Hello" }]
-			const mockGetTaskWithId = jest
-				.spyOn(taskHistory as any, "getTaskWithId")
+                        const mockGetTaskWithId = jest
+                                .spyOn(taskHistory, "getTaskWithId")
 				.mockResolvedValue({ historyItem: mockHistoryItem, apiConversationHistory: mockApiHistory })
 
 			// Execute
@@ -332,12 +332,9 @@ describe("TheaTaskHistory", () => {
 		test("deletes task data, directory, and shadow checkpoints", async () => {
 			// Setup
 			const taskId = "test-task-id"
-			const taskDirPath = path.join("/test/storage/path", "tasks", taskId)
-			const mockGetTaskWithId = jest.spyOn(taskHistory as any, "getTaskWithId").mockResolvedValue({ taskDirPath })
-
-			const mockDeleteTaskFromState = jest
-				.spyOn(taskHistory as any, "deleteTaskFromState")
-				.mockResolvedValue(undefined)
+                        const taskDirPath = path.join("/test/storage/path", "tasks", taskId)
+                        jest.spyOn(taskHistory, "getTaskWithId").mockResolvedValue({ taskDirPath })
+                        jest.spyOn(taskHistory, "deleteTaskFromState").mockResolvedValue(undefined)
 
 			// Mock getCurrentCline to return a different task ID
 			const mockGetCurrentCline = jest.fn().mockReturnValue({ taskId: "different-task-id" })
@@ -361,12 +358,10 @@ describe("TheaTaskHistory", () => {
 		test("finishes subtask when deleting current task", async () => {
 			// Setup
 			const taskId = "current-task-id"
-			const taskDirPath = path.join("/test/storage/path", "tasks", taskId)
-			const mockGetTaskWithId = jest.spyOn(taskHistory as any, "getTaskWithId").mockResolvedValue({ taskDirPath })
+                        const taskDirPath = path.join("/test/storage/path", "tasks", taskId)
+                        jest.spyOn(taskHistory, "getTaskWithId").mockResolvedValue({ taskDirPath })
 
-			const mockDeleteTaskFromState = jest
-				.spyOn(taskHistory as any, "deleteTaskFromState")
-				.mockResolvedValue(undefined)
+                        jest.spyOn(taskHistory, "deleteTaskFromState").mockResolvedValue(undefined)
 
 			// Mock getCurrentCline to return the same task ID
 			const mockGetCurrentCline = jest.fn().mockReturnValue({ taskId })
@@ -382,9 +377,9 @@ describe("TheaTaskHistory", () => {
 		test("handles task not found error", async () => {
 			// Setup
 			const taskId = "non-existent-id"
-			const mockGetTaskWithId = jest
-				.spyOn(taskHistory as any, "getTaskWithId")
-				.mockRejectedValue(new Error("Task non-existent-id not found"))
+                        jest
+                                .spyOn(taskHistory, "getTaskWithId")
+                                .mockRejectedValue(new Error("Task non-existent-id not found"))
 
 			const mockGetCurrentCline = jest.fn()
 			const mockFinishSubTask = jest.fn()
@@ -399,12 +394,9 @@ describe("TheaTaskHistory", () => {
 		test("handles shadow checkpoint deletion error", async () => {
 			// Setup
 			const taskId = "test-task-id"
-			const taskDirPath = path.join("/test/storage/path", "tasks", taskId)
-			const mockGetTaskWithId = jest.spyOn(taskHistory as any, "getTaskWithId").mockResolvedValue({ taskDirPath })
-
-			const mockDeleteTaskFromState = jest
-				.spyOn(taskHistory as any, "deleteTaskFromState")
-				.mockResolvedValue(undefined)
+                        const taskDirPath = path.join("/test/storage/path", "tasks", taskId)
+                        jest.spyOn(taskHistory, "getTaskWithId").mockResolvedValue({ taskDirPath })
+                        jest.spyOn(taskHistory, "deleteTaskFromState").mockResolvedValue(undefined)
 
 			// Mock ShadowCheckpointService to throw an error
 			const mockError = new Error("Shadow deletion error")

--- a/src/core/webview/__tests__/TheaTaskStack.test.ts
+++ b/src/core/webview/__tests__/TheaTaskStack.test.ts
@@ -1,4 +1,5 @@
 // filepath: /Volumes/stuff/Projects/Thea-Code/src/core/webview/__tests__/TheaTaskStack.test.ts
+/* eslint-disable @typescript-eslint/unbound-method */
 import { TheaTaskStack } from "../thea/TheaTaskStack" // Renamed import and path
 import { TheaTask } from "../../TheaTask" // Renamed import
 
@@ -26,10 +27,12 @@ describe("TheaTaskStack", () => {
 
 	test("addCline adds a TheaTask instance to the stack", async () => {
 		// Setup
-		const mockTheaTask = {
-			taskId: "test-task-id-1",
-			instanceId: "instance-1",
-		} as unknown as TheaTask
+                const mockTheaTask = {
+                        taskId: "test-task-id-1",
+                        instanceId: "instance-1",
+                        abortTask: jest.fn(),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
 
 		// Execute
 		await theaTaskStack.addTheaTask(mockTheaTask)
@@ -41,8 +44,18 @@ describe("TheaTaskStack", () => {
 
 	test("addCline adds multiple instances correctly", async () => {
 		// Setup
-		const mockTheaTask1 = { taskId: "test-task-id-1", instanceId: "instance-1" } as unknown as TheaTask
-		const mockTheaTask2 = { taskId: "test-task-id-2", instanceId: "instance-2" } as unknown as TheaTask
+                const mockTheaTask1 = {
+                        taskId: "test-task-id-1",
+                        instanceId: "instance-1",
+                        abortTask: jest.fn(),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
+                const mockTheaTask2 = {
+                        taskId: "test-task-id-2",
+                        instanceId: "instance-2",
+                        abortTask: jest.fn(),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
 
 		// Execute
 		await theaTaskStack.addTheaTask(mockTheaTask1)
@@ -56,11 +69,12 @@ describe("TheaTaskStack", () => {
 
 	test("removeCurrentCline removes and aborts the top TheaTask instance", async () => {
 		// Setup
-		const mockTheaTask = {
-			taskId: "test-task-id",
-			instanceId: "instance-1",
-			abortTask: jest.fn().mockResolvedValue(undefined),
-		} as unknown as TheaTask
+                const mockTheaTask = {
+                        taskId: "test-task-id",
+                        instanceId: "instance-1",
+                        abortTask: jest.fn().mockResolvedValue(undefined),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
 		await theaTaskStack.addTheaTask(mockTheaTask)
 
 		// Execute
@@ -82,11 +96,12 @@ describe("TheaTaskStack", () => {
 
 	test("removeCurrentCline handles abort errors gracefully", async () => {
 		// Setup
-		const mockTheaTask = {
-			taskId: "test-task-id",
-			instanceId: "instance-1",
-			abortTask: jest.fn().mockRejectedValue(new Error("Abort error")),
-		} as unknown as TheaTask
+                const mockTheaTask = {
+                        taskId: "test-task-id",
+                        instanceId: "instance-1",
+                        abortTask: jest.fn().mockRejectedValue(new Error("Abort error")),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
 		await theaTaskStack.addTheaTask(mockTheaTask)
 
 		// Execute
@@ -101,8 +116,16 @@ describe("TheaTaskStack", () => {
 
 	test("getCurrentCline returns the top instance", async () => {
 		// Setup
-		const mockTheaTask1 = { taskId: "test-task-id-1" } as unknown as TheaTask
-		const mockTheaTask2 = { taskId: "test-task-id-2" } as unknown as TheaTask
+                const mockTheaTask1 = {
+                        taskId: "test-task-id-1",
+                        abortTask: jest.fn(),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
+                const mockTheaTask2 = {
+                        taskId: "test-task-id-2",
+                        abortTask: jest.fn(),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
 		await theaTaskStack.addTheaTask(mockTheaTask1)
 		await theaTaskStack.addTheaTask(mockTheaTask2)
 
@@ -123,8 +146,16 @@ describe("TheaTaskStack", () => {
 
 	test("getSize returns the number of instances in the stack", async () => {
 		// Setup
-		const mockTheaTask1 = { taskId: "test-task-id-1" } as unknown as TheaTask
-		const mockTheaTask2 = { taskId: "test-task-id-2" } as unknown as TheaTask
+                const mockTheaTask1 = {
+                        taskId: "test-task-id-1",
+                        abortTask: jest.fn(),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
+                const mockTheaTask2 = {
+                        taskId: "test-task-id-2",
+                        abortTask: jest.fn(),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
 
 		// Execute & Verify - Empty stack
 		expect(theaTaskStack.getSize()).toBe(0)
@@ -145,8 +176,16 @@ describe("TheaTaskStack", () => {
 
 	test("getTaskStack returns an array of task IDs", async () => {
 		// Setup
-		const mockTheaTask1 = { taskId: "test-task-id-1" } as unknown as TheaTask
-		const mockTheaTask2 = { taskId: "test-task-id-2" } as unknown as TheaTask
+                const mockTheaTask1 = {
+                        taskId: "test-task-id-1",
+                        abortTask: jest.fn(),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
+                const mockTheaTask2 = {
+                        taskId: "test-task-id-2",
+                        abortTask: jest.fn(),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
 		await theaTaskStack.addTheaTask(mockTheaTask1)
 		await theaTaskStack.addTheaTask(mockTheaTask2)
 
@@ -159,15 +198,17 @@ describe("TheaTaskStack", () => {
 
 	test("finishSubTask removes current task and resumes parent task", async () => {
 		// Setup
-		const mockParentTheaTask = {
-			taskId: "parent-task-id",
-			resumePausedTask: jest.fn(),
-		} as unknown as TheaTask
+                const mockParentTheaTask = {
+                        taskId: "parent-task-id",
+                        abortTask: jest.fn(),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
 
-		const mockSubTaskTheaTask = {
-			taskId: "subtask-id",
-			abortTask: jest.fn().mockResolvedValue(undefined),
-		} as unknown as TheaTask
+                const mockSubTaskTheaTask = {
+                        taskId: "subtask-id",
+                        abortTask: jest.fn().mockResolvedValue(undefined),
+                        resumePausedTask: jest.fn(),
+                } as unknown as jest.Mocked<TheaTask>
 
 		await theaTaskStack.addTheaTask(mockParentTheaTask)
 		await theaTaskStack.addTheaTask(mockSubTaskTheaTask)


### PR DESCRIPTION
## Summary
- address ESLint complaints in TheaTaskStack.test
- tidy TheaTaskHistory.test mocks
- clean up TheaStateManager.test and remove stray awaits

## Testing
- `npm run lint`