### PR TITLE
Fix lint warnings in tests

### DIFF
--- a/src/core/config/__tests__/ProviderSettingsManager.test.ts
+++ b/src/core/config/__tests__/ProviderSettingsManager.test.ts
@@ -74,7 +74,9 @@ describe("ProviderSettingsManager", () => {
 
 			// Should have written the config with new IDs
 			expect(mockSecrets.store).toHaveBeenCalled()
-			const storedConfig = JSON.parse(mockSecrets.store.mock.calls[0][1])
+                        const storedConfig = JSON.parse(
+                                mockSecrets.store.mock.calls[0][1] as string,
+                        ) as ProviderProfiles
 			expect(storedConfig.apiConfigs.default.id).toBeTruthy()
 			expect(storedConfig.apiConfigs.test.id).toBeTruthy()
 		})
@@ -167,7 +169,9 @@ describe("ProviderSettingsManager", () => {
 			await providerSettingsManager.saveConfig("test", newConfig)
 
 			// Get the actual stored config to check the generated ID
-			const storedConfig = JSON.parse(mockSecrets.store.mock.calls[0][1])
+                        const storedConfig = JSON.parse(
+                                mockSecrets.store.mock.calls[0][1] as string,
+                        ) as ProviderProfiles
 			const testConfigId = storedConfig.apiConfigs.test.id
 
 			const expectedConfig = {

--- a/src/core/webview/__tests__/TheaProvider.test.ts
+++ b/src/core/webview/__tests__/TheaProvider.test.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode"
-import EventEmitter from "events"
 import { TheaProvider } from "../TheaProvider" // Renamed import
 import { TheaTaskStack } from "../thea/TheaTaskStack" // Renamed import and path
 import { TheaStateManager } from "../thea/TheaStateManager" // Renamed import and path


### PR DESCRIPTION
## Summary
- clean up unused EventEmitter import in `TheaProvider.test`
- specify types for stored config in `ProviderSettingsManager` tests

## Testing
- `npm run lint`
- `npm test` *(fails: 20 failing tests)*