### PR TITLE
Fix extension build and tree-sitter wasm handling

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	outputChannel.appendLine(`${EXTENSION_DISPLAY_NAME} extension activated`)
 
 	// Detect e2e/test mode to reduce heavy startup during integration tests
-	const isE2E = process.env.THEA_E2E === '1' || process.env.NODE_ENV === 'test'
+	const isE2E = process.env.THEA_E2E === "1" || process.env.NODE_ENV === "test"
 	outputChannel.appendLine(`Activation starting (testMode=${isE2E})`)
 
 	if (isE2E) {
@@ -161,11 +161,6 @@ export async function deactivate() {
 	outputChannel.appendLine(`${EXTENSION_DISPLAY_NAME} extension deactivated`)
 	// Clean up MCP server manager
 	await McpServerManager.cleanup(extensionContext)
-	await telemetryService.shutdown()
-
-	// Clean up terminal handlers
-	TerminalRegistry.cleanup()
-}
 	await telemetryService.shutdown()
 
 	// Clean up terminal handlers

--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react"
+import type { ZodIssue } from "zod"
 import { GLOBAL_FILENAMES, CONFIG_DIR_NAME } from "../../../../src/shared/config/thea-config"
 import {
 	VSCodeButton,
@@ -227,10 +228,10 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 		const result = modeConfigSchema.safeParse(newMode)
 
 		if (!result.success) {
-			// Map Zod errors to specific fields
-			result.error.errors.forEach((error) => {
-				const field = error.path[0] as string
-				const message = error.message
+			// Map Zod issues to specific fields
+			result.error.issues.forEach((issue: ZodIssue) => {
+				const field = issue.path[0] as string
+				const message = issue.message
 
 				switch (field) {
 					case "name":

--- a/webview-ui/src/components/ui/hooks/useOpenRouterModelProviders.ts
+++ b/webview-ui/src/components/ui/hooks/useOpenRouterModelProviders.ts
@@ -72,11 +72,11 @@ async function getOpenRouterProvidersForModel(modelId: string) {
 				description,
 				label: providerName,
 			}
-			
+
 			// Set default cache pricing
 			modelInfo.cacheWritesPrice = 0.3
 			modelInfo.cacheReadsPrice = 0.03
-			
+
 			// Use the capability detection system to set capabilities based on model ID patterns
 			const updated = setCapabilitiesFromModelId(modelId, modelInfo)
 			// Preserve label if helper returns a new object without it in the type
@@ -86,7 +86,7 @@ async function getOpenRouterProvidersForModel(modelId: string) {
 		}
 	} catch (error) {
 		if (error instanceof z.ZodError) {
-			console.error(`OpenRouter API response validation failed:`, error.errors)
+			console.error(`OpenRouter API response validation failed:`, error.issues)
 		} else {
 			console.error(`Error fetching OpenRouter providers:`, error)
 		}


### PR DESCRIPTION
## Summary
- remove duplicate cleanup code in `deactivate` and fix syntax
- copy tree-sitter wasm files safely during build
- update webview components for latest zod error API

## Testing
- `node ../out/e2e/runTest.js` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b00104bac483338835041c29584106