### PR TITLE
Parallelize async operations

### DIFF
--- a/src/api/providers/provider-factory.ts
+++ b/src/api/providers/provider-factory.ts
@@ -187,16 +187,16 @@ export async function findModelAcrossProviders(modelId: string): Promise<{
 	const factory = ProviderFactory.getInstance()
 	factory.initialize()
 	
-	const providers = modelRegistry.getProviderNames()
-	
-	for (const provider of providers) {
-		const info = await modelRegistry.getModelInfo(provider, modelId)
-		if (info) {
-			return { provider, info }
-		}
-	}
-	
-	return null
+        const providers = modelRegistry.getProviderNames()
+
+        const infos = await Promise.all(
+                providers.map(async (provider) => ({
+                        provider,
+                        info: await modelRegistry.getModelInfo(provider, modelId),
+                })),
+        )
+
+        return infos.find(({ info }) => info) || null
 }
 
 /**

--- a/src/services/tree-sitter/languageParser.ts
+++ b/src/services/tree-sitter/languageParser.ts
@@ -60,78 +60,86 @@ Sources:
 */
 export async function loadRequiredLanguageParsers(filesToParse: string[]): Promise<LanguageParser> {
 	initializeParser()
-	const extensionsToLoad = new Set(filesToParse.map((file) => path.extname(file).toLowerCase().slice(1)))
-	const parsers: LanguageParser = {}
-	for (const ext of extensionsToLoad) {
-		let language: Parser.Language
-		let query: Parser.Query
-		switch (ext) {
-			case "js":
-			case "jsx":
-				language = await loadLanguage("javascript")
-				query = language.query(javascriptQuery)
-				break
-			case "ts":
-				language = await loadLanguage("typescript")
-				query = language.query(typescriptQuery)
-				break
-			case "tsx":
-				language = await loadLanguage("tsx")
-				query = language.query(typescriptQuery)
-				break
-			case "py":
-				language = await loadLanguage("python")
-				query = language.query(pythonQuery)
-				break
-			case "rs":
-				language = await loadLanguage("rust")
-				query = language.query(rustQuery)
-				break
-			case "go":
-				language = await loadLanguage("go")
-				query = language.query(goQuery)
-				break
-			case "cpp":
-			case "hpp":
-				language = await loadLanguage("cpp")
-				query = language.query(cppQuery)
-				break
-			case "c":
-			case "h":
-				language = await loadLanguage("c")
-				query = language.query(cQuery)
-				break
-			case "cs":
-				language = await loadLanguage("c_sharp")
-				query = language.query(csharpQuery)
-				break
-			case "rb":
-				language = await loadLanguage("ruby")
-				query = language.query(rubyQuery)
-				break
-			case "java":
-				language = await loadLanguage("java")
-				query = language.query(javaQuery)
-				break
-			case "php":
-				language = await loadLanguage("php")
-				query = language.query(phpQuery)
-				break
-			case "swift":
-				language = await loadLanguage("swift")
-				query = language.query(swiftQuery)
-				break
-			case "kt":
-			case "kts":
-				language = await loadLanguage("kotlin")
-				query = language.query(kotlinQuery)
-				break
-			default:
-				throw new Error(`Unsupported language: ${ext}`)
-		}
-		const parser = new Parser.Parser()
-		parser.setLanguage(language)
-		parsers[ext] = { parser, query }
-	}
-	return parsers
+        const extensionsToLoad = new Set(filesToParse.map((file) => path.extname(file).toLowerCase().slice(1)))
+        const parsers: LanguageParser = {}
+
+        const entries = await Promise.all(
+                Array.from(extensionsToLoad).map(async (ext) => {
+                        let language: Parser.Language
+                        let query: Parser.Query
+                        switch (ext) {
+                                case "js":
+                                case "jsx":
+                                        language = await loadLanguage("javascript")
+                                        query = language.query(javascriptQuery)
+                                        break
+                                case "ts":
+                                        language = await loadLanguage("typescript")
+                                        query = language.query(typescriptQuery)
+                                        break
+                                case "tsx":
+                                        language = await loadLanguage("tsx")
+                                        query = language.query(typescriptQuery)
+                                        break
+                                case "py":
+                                        language = await loadLanguage("python")
+                                        query = language.query(pythonQuery)
+                                        break
+                                case "rs":
+                                        language = await loadLanguage("rust")
+                                        query = language.query(rustQuery)
+                                        break
+                                case "go":
+                                        language = await loadLanguage("go")
+                                        query = language.query(goQuery)
+                                        break
+                                case "cpp":
+                                case "hpp":
+                                        language = await loadLanguage("cpp")
+                                        query = language.query(cppQuery)
+                                        break
+                                case "c":
+                                case "h":
+                                        language = await loadLanguage("c")
+                                        query = language.query(cQuery)
+                                        break
+                                case "cs":
+                                        language = await loadLanguage("c_sharp")
+                                        query = language.query(csharpQuery)
+                                        break
+                                case "rb":
+                                        language = await loadLanguage("ruby")
+                                        query = language.query(rubyQuery)
+                                        break
+                                case "java":
+                                        language = await loadLanguage("java")
+                                        query = language.query(javaQuery)
+                                        break
+                                case "php":
+                                        language = await loadLanguage("php")
+                                        query = language.query(phpQuery)
+                                        break
+                                case "swift":
+                                        language = await loadLanguage("swift")
+                                        query = language.query(swiftQuery)
+                                        break
+                                case "kt":
+                                case "kts":
+                                        language = await loadLanguage("kotlin")
+                                        query = language.query(kotlinQuery)
+                                        break
+                                default:
+                                        throw new Error(`Unsupported language: ${ext}`)
+                        }
+                        const parser = new Parser.Parser()
+                        parser.setLanguage(language)
+                        return [ext, { parser, query }] as const
+                }),
+        )
+
+        for (const [ext, parserInfo] of entries) {
+                parsers[ext] = parserInfo
+        }
+
+        return parsers
 }


### PR DESCRIPTION
## Summary
- process rule files, source definitions, and tree-sitter language loaders concurrently
- parallelize model registry lookups, tool execution, and git diff generation
- scan network hosts concurrently to discover browser endpoints

## Testing
- `npm run test:unit` *(terminated)*
- `npm run test:types` *(failed: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c53fceab508333acb9e632ac8eca97