### PR TITLE
Eliminate vscode imports from e2e tests

### DIFF
--- a/src/e2e/src/suite/api/transform/vscode-lm-format.test.ts
+++ b/src/e2e/src/suite/api/transform/vscode-lm-format.test.ts
@@ -1,231 +1,156 @@
 import * as assert from 'assert'
-import * as sinon from 'sinon'
-import type { NeutralConversationHistory } from "../../../shared/neutral-history"
-import * as vscode from "vscode"
+import type { NeutralConversationHistory } from '../../../shared/neutral-history'
 
-import { convertToVsCodeLmMessages, convertToAnthropicRole } from "../vscode-lm-format"
+import { convertToVsCodeLmMessages, convertToAnthropicRole } from '../vscode-lm-format'
 
-// Define types for our mocked classes
-interface MockLanguageModelTextPart {
-	type: "text"
-	value: string
-}
+suite('convertToVsCodeLmMessages', () => {
+  test('converts simple string messages', () => {
+    const messages: NeutralConversationHistory = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' }
+    ]
 
-interface MockLanguageModelToolCallPart {
-	type: "tool_call"
-	callId: string
-	name: string
-	input: Record<string, unknown>
-}
+    const result = convertToVsCodeLmMessages(messages)
 
-interface MockLanguageModelToolResultPart {
-	type: "tool_result"
-	toolUseId: string
-	parts: MockLanguageModelTextPart[]
-}
+    assert.strictEqual(result.length, 2)
+    assert.strictEqual(result[0].content[0].value, 'Hello')
+    assert.strictEqual(result[1].content[0].value, 'Hi there')
+    assert.strictEqual(convertToAnthropicRole(result[0].role), 'user')
+    assert.strictEqual(convertToAnthropicRole(result[1].role), 'assistant')
+  })
 
-// Mock vscode namespace
-// Mock needs manual implementation
-		Assistant: "assistant",
-		User: "user",
-	}
+  test('handles complex user messages with tool results', () => {
+    const messages: NeutralConversationHistory = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Here is the result:' },
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-1',
+            content: [{ type: 'text', text: 'Tool output' }]
+          }
+        ]
+      }
+    ]
 
-	class MockLanguageModelTextPart {
-		type = "text"
-		constructor(public value: string) {}
-	}
+    const result = convertToVsCodeLmMessages(messages)
 
-	class MockLanguageModelToolCallPart {
-		type = "tool_call"
-		constructor(
-			public callId: string,
-			public name: string,
-			public input: Record<string, unknown>,
-		) {}
-	}
+    assert.strictEqual(result.length, 1)
+    assert.strictEqual(result[0].content.length, 2)
+    const [toolResult, textContent] = result[0].content
+    assert.strictEqual(toolResult.constructor.name, 'LanguageModelToolResultPart')
+    assert.strictEqual(textContent.constructor.name, 'LanguageModelTextPart')
+  })
 
-	class MockLanguageModelToolResultPart {
-		type = "tool_result"
-		constructor(
-			public toolUseId: string,
-			public parts: MockLanguageModelTextPart[],
-		) {}
-	}
-// Mock removed - needs manual implementation)),
-// 			User: sinon.stub((content: string | MockLanguageModelTextPart[]) => ({
-// 				role: LanguageModelChatMessageRole.User,
-// 				name: "user",
-// 				content: Array.isArray(content) ? content : [new MockLanguageModelTextPart(content)],
-// 			})),
-// 		},
-// 		LanguageModelChatMessageRole,
-// 		LanguageModelTextPart: MockLanguageModelTextPart,
-// 		LanguageModelToolCallPart: MockLanguageModelToolCallPart,
-// 		LanguageModelToolResultPart: MockLanguageModelToolResultPart,
-// 	}
-// Mock cleanup
-suite("convertToVsCodeLmMessages", () => {
-	test("should convert simple string messages", () => {
-		const messages: NeutralConversationHistory = [
-			{ role: "user", content: "Hello" },
-			{ role: "assistant", content: "Hi there" },
-		]
+  test('handles complex assistant messages with tool calls', () => {
+    const messages: NeutralConversationHistory = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me help you with that.' },
+          {
+            type: 'tool_use',
+            id: 'tool-1',
+            name: 'calculator',
+            input: { operation: 'add', numbers: [2, 2] }
+          }
+        ]
+      }
+    ]
 
-		const result = convertToVsCodeLmMessages(messages)
+    const result = convertToVsCodeLmMessages(messages)
 
-		assert.strictEqual(result.length, 2)
-		assert.strictEqual(result[0].role, "user")
-		expect((result[0].content[0] as MockLanguageModelTextPart).value).toBe("Hello")
-		assert.strictEqual(result[1].role, "assistant")
-		expect((result[1].content[0] as MockLanguageModelTextPart).value).toBe("Hi there")
-	})
+    assert.strictEqual(result.length, 1)
+    assert.strictEqual(result[0].content.length, 2)
+    const [toolCall, textContent] = result[0].content
+    assert.strictEqual(toolCall.constructor.name, 'LanguageModelToolCallPart')
+    assert.strictEqual(textContent.constructor.name, 'LanguageModelTextPart')
+  })
 
-	test("should handle complex user messages with tool results", () => {
-		const messages: NeutralConversationHistory = [
-			{
-				role: "user",
-				content: [
-					{ type: "text", text: "Here is the result:" },
-					{
-						type: "tool_result",
-						tool_use_id: "tool-1",
-						content: [{ type: "text", text: "Tool output" }],
-					},
-				],
-			},
-		]
+  test('handles image blocks with placeholders', () => {
+    const messages: NeutralConversationHistory = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Look at this:' },
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/png', data: 'base64data' }
+          }
+        ]
+      }
+    ]
 
-		const result = convertToVsCodeLmMessages(messages)
+    const result = convertToVsCodeLmMessages(messages)
 
-		assert.strictEqual(result.length, 1)
-		assert.strictEqual(result[0].role, "user")
-		assert.strictEqual(result[0].content.length, 2)
-		const [toolResult, textContent] = result[0].content as [
-			MockLanguageModelToolResultPart,
-			MockLanguageModelTextPart,
-		]
-		assert.strictEqual(toolResult.type, "tool_result")
-		assert.strictEqual(textContent.type, "text")
-	})
+    assert.strictEqual(result.length, 1)
+    const imagePlaceholder = result[0].content[1]
+    assert.ok(String(imagePlaceholder.value).includes('[Image (base64): image/png not supported by VSCode LM API]'))
+  })
+})
 
-	test("should handle complex assistant messages with tool calls", () => {
-		const messages: NeutralConversationHistory = [
-			{
-				role: "assistant",
-				content: [
-					{ type: "text", text: "Let me help you with that." },
-					{
-						type: "tool_use",
-						id: "tool-1",
-						name: "calculator",
-						input: { operation: "add", numbers: [2, 2] },
-					},
-				],
-			},
-		]
+suite('convertToAnthropicRole', () => {
+  test('maps roles and unknown → null', () => {
+    const assistantRole = convertToVsCodeLmMessages([{ role: 'assistant', content: 'x' }])[0].role
+    const userRole = convertToVsCodeLmMessages([{ role: 'user', content: 'y' }])[0].role
+    assert.strictEqual(convertToAnthropicRole(assistantRole), 'assistant')
+    assert.strictEqual(convertToAnthropicRole(userRole), 'user')
+    assert.strictEqual(convertToAnthropicRole('unknown' as any), null)
+  })
+})
 
-		const result = convertToVsCodeLmMessages(messages)
+suite('asObjectSafe via convertToVsCodeLmMessages', () => {
+  test('parses JSON strings in tool_use input', () => {
+    const messages: NeutralConversationHistory = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: '1',
+            name: 'test',
+            input: { jsonString: '{"foo": "bar"}' }
+          }
+        ]
+      }
+    ]
+    const result = convertToVsCodeLmMessages(messages)
+    const toolCall = result[0].content[0]
+    assert.deepStrictEqual(toolCall.input, { jsonString: '{"foo": "bar"}' })
+  })
 
-		assert.strictEqual(result.length, 1)
-		assert.strictEqual(result[0].role, "assistant")
-		assert.strictEqual(result[0].content.length, 2)
-		const [toolCall, textContent] = result[0].content as [MockLanguageModelToolCallPart, MockLanguageModelTextPart]
-		assert.strictEqual(toolCall.type, "tool_call")
-		assert.strictEqual(textContent.type, "text")
-	})
+  test('handles invalid JSON by returning empty object', () => {
+    const messages: NeutralConversationHistory = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: '2',
+            name: 'test',
+            input: { invalidJson: '{invalid}' }
+          }
+        ]
+      }
+    ]
+    const result = convertToVsCodeLmMessages(messages)
+    const toolCall = result[0].content[0]
+    assert.deepStrictEqual(toolCall.input, { invalidJson: '{invalid}' })
+  })
 
-	test("should handle image blocks with appropriate placeholders", () => {
-		const messages: NeutralConversationHistory = [
-			{
-				role: "user",
-				content: [
-					{ type: "text", text: "Look at this:" },
-					{
-						type: "image",
-						source: {
-							type: "base64",
-							media_type: "image/png",
-							data: "base64data",
-						},
-					},
-				],
-			},
-		]
+  test('clones object inputs', () => {
+    const obj = { a: 1 }
+    const messages: NeutralConversationHistory = [
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: '3', name: 'test', input: obj }]
+      }
+    ]
+    const result = convertToVsCodeLmMessages(messages)
+    const toolCall = result[0].content[0]
+    assert.deepStrictEqual(toolCall.input, obj)
+    assert.notStrictEqual(toolCall.input, obj)
+  })
+})
 
-		const result = convertToVsCodeLmMessages(messages)
-
-		assert.strictEqual(result.length, 1)
-		const imagePlaceholder = result[0].content[1] as MockLanguageModelTextPart
-		assert.ok(imagePlaceholder.value.includes("[Image (base64)): image/png not supported by VSCode LM API]")
-	})
-// Mock cleanup
-suite("convertToAnthropicRole", () => {
-	test("should convert assistant role correctly", () => {
-		const result = convertToAnthropicRole(vscode.LanguageModelChatMessageRole.Assistant)
-		assert.strictEqual(result, "assistant")
-	})
-
-	test("should convert user role correctly", () => {
-		const result = convertToAnthropicRole(vscode.LanguageModelChatMessageRole.User)
-		assert.strictEqual(result, "user")
-	})
-
-	test("should return null for unknown roles", () => {
-		// @ts-expect-error Testing with an invalid role value
-		const result = convertToAnthropicRole("unknown")
-		assert.strictEqual(result, null)
-	})
-// Mock cleanup
-suite("asObjectSafe via convertToVsCodeLmMessages", () => {
-	test("parses JSON strings in tool_use input", () => {
-		const messages: NeutralConversationHistory = [
-			{
-				role: "assistant",
-				content: [
-					{
-						type: "tool_use",
-						id: "1",
-						name: "test",
-						input: { jsonString: '{"foo": "bar"}' },
-					},
-				],
-			},
-		]
-		const result = convertToVsCodeLmMessages(messages)
-		const toolCall = result[0].content[0] as MockLanguageModelToolCallPart
-		assert.deepStrictEqual(toolCall.input, { jsonString: '{"foo": "bar"}' })
-	})
-
-	test("handles invalid JSON by returning empty object", () => {
-		const messages: NeutralConversationHistory = [
-			{
-				role: "assistant",
-				content: [
-					{
-						type: "tool_use",
-						id: "2",
-						name: "test",
-						input: { invalidJson: "{invalid}" },
-					},
-				],
-			},
-		]
-		const result = convertToVsCodeLmMessages(messages)
-		const toolCall = result[0].content[0] as MockLanguageModelToolCallPart
-		assert.deepStrictEqual(toolCall.input, { invalidJson: "{invalid}" })
-	})
-
-	test("clones object inputs", () => {
-		const obj = { a: 1 }
-		const messages: NeutralConversationHistory = [
-			{
-				role: "assistant",
-				content: [{ type: "tool_use", id: "3", name: "test", input: obj }],
-			},
-		]
-		const result = convertToVsCodeLmMessages(messages)
-		const toolCall = result[0].content[0] as MockLanguageModelToolCallPart
-		assert.deepStrictEqual(toolCall.input, obj)
-		assert.notStrictEqual(toolCall.input, obj)
-	})
-// Mock cleanup

--- a/test/roo-migration/suite/api-transform-vscode-lm-format-converted.test.js
+++ b/test/roo-migration/suite/api-transform-vscode-lm-format-converted.test.js
@@ -1,9 +1,6 @@
 const assert = require('assert')
 const { loadTheaModule } = require('../helpers/thea-loader')
 
-// Use the local stubbed 'vscode' module provided under test/roo-migration/node_modules
-const vscode = require('vscode')
-
 describe('Roo-migration: api/transform/vscode-lm-format', function () {
   const mod = loadTheaModule('src/api/transform/vscode-lm-format.ts')
   const { convertToVsCodeLmMessages, convertToAnthropicRole } = mod
@@ -25,8 +22,8 @@ describe('Roo-migration: api/transform/vscode-lm-format', function () {
     assert.strictEqual(convertToAnthropicRole(result[0].role), 'user')
     assert.strictEqual(result[0].content.length, 2)
     const [toolResult, textContent] = result[0].content
-    assert.ok(toolResult instanceof vscode.LanguageModelToolResultPart)
-    assert.ok(textContent instanceof vscode.LanguageModelTextPart)
+    assert.strictEqual(toolResult.constructor.name, 'LanguageModelToolResultPart')
+    assert.strictEqual(textContent.constructor.name, 'LanguageModelTextPart')
   })
 
   it('handles complex assistant messages with tool calls', function () {
@@ -36,8 +33,8 @@ describe('Roo-migration: api/transform/vscode-lm-format', function () {
     assert.strictEqual(convertToAnthropicRole(result[0].role), 'assistant')
     assert.strictEqual(result[0].content.length, 2)
     const [toolCall, textContent] = result[0].content
-    assert.ok(toolCall instanceof vscode.LanguageModelToolCallPart)
-    assert.ok(textContent instanceof vscode.LanguageModelTextPart)
+    assert.strictEqual(toolCall.constructor.name, 'LanguageModelToolCallPart')
+    assert.strictEqual(textContent.constructor.name, 'LanguageModelTextPart')
   })
 
   it('handles image blocks with placeholders', function () {
@@ -49,8 +46,10 @@ describe('Roo-migration: api/transform/vscode-lm-format', function () {
   })
 
   it('convertToAnthropicRole maps roles and unknown → null', function () {
-    assert.strictEqual(convertToAnthropicRole(vscode.LanguageModelChatMessageRole.Assistant), 'assistant')
-    assert.strictEqual(convertToAnthropicRole(vscode.LanguageModelChatMessageRole.User), 'user')
+    const assistantRole = convertToVsCodeLmMessages([{ role: 'assistant', content: 'x' }])[0].role
+    const userRole = convertToVsCodeLmMessages([{ role: 'user', content: 'y' }])[0].role
+    assert.strictEqual(convertToAnthropicRole(assistantRole), 'assistant')
+    assert.strictEqual(convertToAnthropicRole(userRole), 'user')
     assert.strictEqual(convertToAnthropicRole('unknown'), null)
   })
 })


### PR DESCRIPTION
## Summary
- rewrite e2e test for vscode-lm message conversion to avoid importing `vscode`
- adjust roo-migration test to check constructor names instead of `vscode` types and derive roles for `convertToAnthropicRole`

## Testing
- `npm run test:compile`
- `npm run test:roo-migration` *(fails: MODULE_NOT_FOUND)*
- `npm run test:integration` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run lint` *(fails: 32 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c633fbc3d083338b5fc8af1cc94bba