### PR TITLE
chore: use VS Code test API in e2e

### DIFF
--- a/src/e2e/src/suite/api/providers/vscode-lm.test.ts
+++ b/src/e2e/src/suite/api/providers/vscode-lm.test.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode"
+import type * as vscode from "vscode"
 import { ApiHandlerOptions } from "../../../shared/api"
 import { VsCodeLmHandler } from "../vscode-lm"
 import * as assert from 'assert'

--- a/src/e2e/src/suite/core/config/ProviderSettingsManager.test.ts
+++ b/src/e2e/src/suite/core/config/ProviderSettingsManager.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 import * as sinon from 'sinon'
 import { EXTENSION_SECRETS_PREFIX } from "../../../shared/config/thea-config"
-import { ExtensionContext } from "vscode"
+import type { ExtensionContext } from "vscode"
 
 import { ProviderSettingsManager, ProviderProfiles } from "../ProviderSettingsManager"
 import { ProviderSettings } from "../../../schemas"

--- a/src/e2e/src/suite/shared/support-prompts.test.ts
+++ b/src/e2e/src/suite/shared/support-prompts.test.ts
@@ -1,8 +1,20 @@
 import { supportPrompt } from "../support-prompt"
-import * as vscode from "vscode"
+import type * as vscode from "vscode"
 
 import * as assert from 'assert'
-import * as vscode from 'vscode'
+
+// Minimal runtime mock for VS Code types used in these tests
+const vscode = {
+  Range: class Range {
+    constructor(
+      public startLine: number,
+      public startChar: number,
+      public endLine: number,
+      public endChar: number,
+    ) {}
+  },
+  DiagnosticSeverity: { Error: 0, Warning: 1 },
+} as unknown as typeof import('vscode');
 suite("Code Action Prompts", () => {
 	const testFilePath = "test/file.ts"
 	const testCode = "function test() { return true; }"

--- a/src/e2e/src/suite/shared/vsCodeSelectorUtils.test.ts
+++ b/src/e2e/src/suite/shared/vsCodeSelectorUtils.test.ts
@@ -1,8 +1,7 @@
 import { stringifyVsCodeLmModelSelector } from "../vsCodeSelectorUtils"
-import { LanguageModelChatSelector } from "vscode"
+import type { LanguageModelChatSelector } from "vscode"
 
 import * as assert from 'assert'
-import * as vscode from 'vscode'
 suite("vsCodeSelectorUtils", () => {
 	suite("stringifyVsCodeLmModelSelector", () => {
 		test("should join all defined selector properties with separator", () => {


### PR DESCRIPTION
## Summary
- replace direct vscode imports in e2e tests with type-only imports
- mock minimal vscode API where runtime stubs are needed

## Testing
- `npm test` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c63d6d531c8333aaf1cccc312e3000